### PR TITLE
Add queryIpInfo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "ipquery.kotlin"
-version = "1.0.1"
+version = "1.0.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/IpQuery.kt
+++ b/src/main/kotlin/IpQuery.kt
@@ -17,11 +17,22 @@ class IpQuery {
 		// ---------------------------------------------------------------------
 		/**
 		 * Query the IP of the current machine
-		 * @return The IP information of the current machine
+		 * @return The IP of the current machine
 		 * @throws RuntimeException If the request fails
 		 */
 		fun queryIp(): String {
-			return makeRequest(URI.create("$BASE_URL$DEFAULT_FORMAT"))
+			return makeRequest(URI.create("$BASE_URL?format=text"))
+		}
+
+		// ---------------------------------------------------------------------
+		/**
+		 * Query the IP information of the current machine
+		 * @return The IP information of the current machine
+		 * @throws RuntimeException If the request fails
+		 */
+		fun queryIpInfo(): IpInfo {
+			val responseBody = makeRequest(URI.create("$BASE_URL$DEFAULT_FORMAT"))
+			return gson.fromJson(responseBody, IpInfo::class.java)
 		}
 
 		// ---------------------------------------------------------------------

--- a/src/test/kotlin/IpQueryTest.kt
+++ b/src/test/kotlin/IpQueryTest.kt
@@ -1,5 +1,6 @@
 import info.IpInfo
 import java.net.InetAddress
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.reflect.full.memberProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -44,6 +45,15 @@ class IpQueryTest {
 		val ownIp = IpQuery.queryIp()
 		assertNotNull(ownIp)
 		assertTrue { ownIp.isNotBlank() }
+		// Should be a valid IP address
+		assertDoesNotThrow { InetAddress.getByName(ownIp) }
+	}
+
+	@Test
+	fun testQueryOwnIpInfo() {
+		val ownIpInfo = IpQuery.queryIpInfo()
+		assertNotNull(ownIpInfo)
+		assertIpInfoNotNull(ownIpInfo)
 	}
 
 	private fun assertIpInfoNotNull(obj: IpInfo) {


### PR DESCRIPTION
Query information about the own IP.
More information about the own IP is only sent if the format is explicitly set to something non-text based. 
Therefore, the original "`queryIp`" now sets the format explicitly to "text" to avoid issues on future changes